### PR TITLE
Explicitly disable Rails sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'ice_nine'
 gem 'memoist'
 gem 'redcarpet'
 gem 'silencer'
+gem 'session_off'
 
 group :production do
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    session_off (0.5.1)
+      actionpack (>= 2.3)
     sexp_processor (4.6.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -363,6 +365,7 @@ DEPENDENCIES
   rspec-rails (~> 3.3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  session_off
   shoulda-matchers
   silencer
   simple_form
@@ -381,4 +384,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,5 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  session :off
+  
   http_basic_authenticate_with name: $auth_name, password: $auth_password unless Rails.env.development? || Rails.env.test?
 end

--- a/spec/controllers/surveys_controller_spec.rb
+++ b/spec/controllers/surveys_controller_spec.rb
@@ -17,12 +17,22 @@ RSpec.describe SurveysController, type: :controller do
         get :show, id: 'sample-survey'
         expect(assigns(:md)).to_not be_nil
       end
+
+      it 'should not set a session cookie' do
+        get :show, id: 'sample-survey'
+        expect(session).to be_empty
+      end
     end
 
     context 'for a nonexistant survey' do
       it 'should return a 404' do
         get :show, id: 'blah'
         expect(response).to have_http_status(:not_found)
+      end
+
+      it 'should not set a session cookie' do
+        get :show, id: 'blah'
+        expect(session).to be_empty
       end
     end
 
@@ -31,6 +41,11 @@ RSpec.describe SurveysController, type: :controller do
         expect_any_instance_of(Survey).to receive(:active?).and_return(false)
         get :show, id: 'sample-survey'
         expect(response).to have_http_status(:not_found)
+      end
+
+      it 'should not set a session cookie' do
+        get :show, id: 'sample-survey'
+        expect(session).to be_empty
       end
     end
 
@@ -45,6 +60,11 @@ RSpec.describe SurveysController, type: :controller do
         expect_any_instance_of(Survey).to receive(:active?).and_return(false)
         get :show, id: 'sample-survey', format: 'json'
         expect(response).to have_http_status(:not_found)
+      end
+
+      it 'should not set a session cookie' do
+        get :show, id: 'sample-survey', format: 'json'
+        expect(session).to be_empty
       end
     end
   end


### PR DESCRIPTION
Rails is only supposed to enable sessions when they are used, but I have seen them in OWASP and I want to make sure there is no way the session cookie or ANY cookie is set
