### PR TITLE
Hide response counts when survey active

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,6 +1,6 @@
 # The only controller we need for handling the survey form for now
 class SurveysController < ApplicationController
-  before_action :load_survey, only: [:submit, :show, :survey_json, :results, :generate_token, :revoke_tokens]
+  before_action :load_survey, only: [:submit, :show, :results, :generate_token, :revoke_tokens]
 
   def show
     check_access_allowed!
@@ -9,6 +9,7 @@ class SurveysController < ApplicationController
   end
 
   def survey_json
+    @survey = Survey.new(params[:id])
     render json: Serializers::Survey.new(@survey).as_json
   end
 

--- a/app/models/serializers/survey.rb
+++ b/app/models/serializers/survey.rb
@@ -1,14 +1,19 @@
 module Serializers
   class Survey < SimpleDelegator
     def as_json
-      {
+      out = {
         id: survey_id,
         title: title,
         description: description,
-        participants: participants,
-        questions: questions.map {|q| Serializers::Question.new(q).as_json },
-        intersections: intersections.map {|i| Serializers::Intersection.new(i).as_json }
+        participants: participants
       }
+
+      unless active?
+        out[:questions] = questions.map {|q| Serializers::Question.new(q).as_json }
+        out[:intersections] = intersections.map {|i| Serializers::Intersection.new(i).as_json }
+      end
+
+      out
     end
   end
 end


### PR DESCRIPTION
This commit changes the survey JSON response to only return the questions and intersections with their associated response counts when the survey is inactive. This is to prevent anyone from seeing totals while the survey is running to disable some possible attacks on user privacy.
